### PR TITLE
Fix get hostname bug

### DIFF
--- a/src/main/java/bridge/intercept/WebLogIntercept.java
+++ b/src/main/java/bridge/intercept/WebLogIntercept.java
@@ -35,7 +35,7 @@ public class WebLogIntercept implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        String host = request.getHeader("host");
+        String host = request.getHeader("host").replaceAll(":(.*)", "").strip();
         Integer logID;
         if (host.equals(DnslogConfig.managerDomain)) {
             return true;


### PR DESCRIPTION
I've noticed that if I change port from 80 to 8080, I can't access to the admin panel, it'll throw out `request host no logid found`.

I think it might be a good idea here to get `hostname/domain` here, not getting `host` from header. Because host includes port.

When I request `http://www.example.com:8080/admin`, the host is `www.example.com:8080`, but I need `www.example.com`.

I've tested in Docker image, the problem remains.